### PR TITLE
Fix message to reflect new 'All activity' field

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -266,7 +266,7 @@
         "other": {
             "heading": "Autres options",
             "hideDeleted": "Cacher les jeux supprimés",
-            "hideDeletedHint": "N'affiche pas les jeux supprimés dans 'Toute l'activité'.",
+            "hideDeletedHint": "N'affiche pas les jeux supprimés dans 'Activité complète'.",
             "replace": "Remplacer la page utilisateur",
             "replaceBox": {
                 "error": "Une erreur est survenue :",


### PR DESCRIPTION
The field was changed in the previous version but this message does not reflect these changes.

Toute l'activité => Activité complète